### PR TITLE
Added context gate. I have added the three versions "source", "target…

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The following OpenNMT features are implemented:
 - saving and loading from checkpoints
 - inference (translation) with batching and beam search
 - multi-GPU
+- Context gate
 
 Not yet implemented:
 

--- a/onmt/modules/Gate.py
+++ b/onmt/modules/Gate.py
@@ -1,0 +1,90 @@
+"""
+Context gate is a decoder module that takes as input the previous word
+embedding, the current decoder state and the attention state, and produces a
+gate.
+The gate can be used to select the input from the target side context
+(decoder state), from the source context (attention state) or both.
+"""
+import torch
+import torch.nn as nn
+
+
+def ContextGateFactory(type, embeddings_size, decoder_size,
+                       attention_size, output_size):
+    """Returns the correct ContextGate class"""
+
+    gate_types = {'source': SourceContextGate,
+                  'target': TargetContextGate,
+                  'both': BothContextGate}
+
+    assert type in gate_types, "Not valid ContextGate type: {0}".format(type)
+    return gate_types[type](embeddings_size, decoder_size, attention_size,
+                            output_size)
+
+
+class ContextGate(nn.Module):
+    """Implement up to the computation of the gate"""
+
+    def __init__(self, embeddings_size, decoder_size,
+                 attention_size, output_size):
+        super(ContextGate, self).__init__()
+        input_size = embeddings_size + decoder_size + attention_size
+        self.gate = nn.Linear(input_size, output_size, bias=True)
+        self.sig = nn.Sigmoid()
+        self.source_proj = nn.Linear(attention_size, output_size)
+        self.target_proj = nn.Linear(embeddings_size + decoder_size,
+                                     output_size)
+
+    def forward(self, prev_emb, dec_state, attn_state):
+        input_tensor = torch.cat((prev_emb, dec_state, attn_state), dim=2)
+        z = self.sig(self.gate(input_tensor))
+        proj_source = self.source_proj(attn_state)
+        proj_target = self.target_proj(
+            torch.cat((prev_emb, dec_state), dim=2))
+        return z, proj_source, proj_target
+
+
+class SourceContextGate(nn.Module):
+    """Apply the context gate only to the source context"""
+
+    def __init__(self, embeddings_size, decoder_size,
+                 attention_size, output_size):
+        super(SourceContextGate, self).__init__()
+        self.context_gate = ContextGate(embeddings_size, decoder_size,
+                                        attention_size, output_size)
+        self.tanh = nn.Tanh()
+
+    def forward(self, prev_emb, dec_state, attn_state):
+        z, source, target = self.context_gate(
+            prev_emb, dec_state, attn_state)
+        return self.tanh(target + z * source)
+
+
+class TargetContextGate(nn.Module):
+    """Apply the context gate only to the target context"""
+
+    def __init__(self, embeddings_size, decoder_size,
+                 attention_size, output_size):
+        super(TargetContextGate, self).__init__()
+        self.context_gate = ContextGate(embeddings_size, decoder_size,
+                                        attention_size, output_size)
+        self.tanh = nn.Tanh()
+
+    def forward(self, prev_emb, dec_state, attn_state):
+        z, source, target = self.context_gate(prev_emb, dec_state, attn_state)
+        return self.tanh(z * target + source)
+
+
+class BothContextGate(nn.Module):
+    """Apply the context gate to both contexts"""
+
+    def __init__(self, embeddings_size, decoder_size,
+                 attention_size, output_size):
+        super(BothContextGate, self).__init__()
+        self.context_gate = ContextGate(embeddings_size, decoder_size,
+                                        attention_size, output_size)
+        self.tanh = nn.Tanh()
+
+    def forward(self, prev_emb, dec_state, attn_state):
+        z, source, target = self.context_gate(prev_emb, dec_state, attn_state)
+        return self.tanh((1. - z) * target + z * source)

--- a/train.py
+++ b/train.py
@@ -52,6 +52,10 @@ parser.add_argument('-brnn', action='store_true',
 parser.add_argument('-brnn_merge', default='concat',
                     help="""Merge action for the bidirectional hidden states:
                     [concat|sum]""")
+parser.add_argument('-context_gate', type=str, default=None,
+                    choices=['source', 'target', 'both'],
+                    help="""Type of context gate to use [source|target|both].
+                    Do not select for no context gate.""")
 
 # Optimization options
 parser.add_argument('-encoder_type', default='text',


### PR DESCRIPTION
…" and "both" context gate as explained in the referenced paper.

I have extended the Decoder class for using the context gate, and it can integrated also in future different decoders very easily.

Reference paper:
Tu, Zhaopeng, et al. "Context gates for neural machine translation." arXiv preprint arXiv:1608.06043 (2016).